### PR TITLE
Fix RSS question filtering based on time stamp

### DIFF
--- a/cron/__main__.py
+++ b/cron/__main__.py
@@ -13,6 +13,7 @@ from .rss_reader import RSSReader
 
 sys.stdout.reconfigure(line_buffering=True)
 
+
 async def rss_to_gitter_job():
 
     # run the script every 10 minutes
@@ -39,9 +40,10 @@ async def rss_to_gitter_job():
                 },
             )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     scheduler = AsyncIOScheduler()
-    scheduler.add_job(rss_to_gitter_job, 'interval', minutes=10)
+    scheduler.add_job(rss_to_gitter_job, "interval", minutes=10)
     scheduler.start()
 
     # Execution will block here until Ctrl+C (Ctrl+Break on Windows) is pressed.
@@ -49,4 +51,3 @@ if __name__ == '__main__':
         asyncio.get_event_loop().run_forever()
     except (KeyboardInterrupt, SystemExit):
         pass
-

--- a/cron/rss_reader.py
+++ b/cron/rss_reader.py
@@ -10,12 +10,8 @@ class RSSReader:
     def read_feed(self, newer_than):
         feed = feedparser.parse(self.feed_url)
 
-        print(len(feed.entries))
-
-        for idx, entry in enumerate(feed.entries):
+        for entry in feed.entries:
             published_ts = datetime.strptime(entry["published"], "%Y-%m-%dT%H:%M:%SZ")
 
-            if published_ts < newer_than:
-                return
-
-            yield entry
+            if published_ts >= newer_than:
+                yield entry

--- a/cron/rss_reader.py
+++ b/cron/rss_reader.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import feedparser
 
@@ -10,11 +10,12 @@ class RSSReader:
     def read_feed(self, newer_than):
         feed = feedparser.parse(self.feed_url)
 
-        for idx, entry in enumerate(feed.entries):
-            published_ts = datetime.fromisoformat(entry["published"].replace("Z", ""))
+        print(len(feed.entries))
 
-            if idx == 0:
-                if published_ts < newer_than:
-                    return
-            else:
-                yield entry
+        for idx, entry in enumerate(feed.entries):
+            published_ts = datetime.strptime(entry["published"], "%Y-%m-%dT%H:%M:%SZ")
+
+            if published_ts < newer_than:
+                return
+
+            yield entry


### PR DESCRIPTION
I have changed the URL for the RSS feeds to sort the feed as newest feed first, and in read feed I am returning if the first feed is older than the desired time. 

It should fix https://github.com/bots-for-humanity/trio-gitter-bot/issues/7 